### PR TITLE
Install kcpfpg when installing tcpborphserver3

### DIFF
--- a/fpg/Makefile
+++ b/fpg/Makefile
@@ -23,5 +23,8 @@ $(EXE): $(OBJ)
 clean:
 	$(RM) $(OBJ) core $(EXE)
 
+# Create symlink in /bin so that the upload_to_ram_and_program
+# command in tcpborphserver3 will work.
 install: all
 	$(INSTALL) $(EXE) $(PREFIX)/bin
+	ln -sf $(PREFIX)/bin/$(EXE) /bin/$(EXE)

--- a/tcpborphserver3/Makefile
+++ b/tcpborphserver3/Makefile
@@ -32,6 +32,9 @@ clean:
 	$(CC) $(CFLAGS) -c $< -o $@ $(INC)
 
 install: all
+	# Ensure that kcpfpg in installed in /usr so
+	# that upload_to_ram_and_program will work!
+	$(MAKE) -C ../fpg PREFIX=/usr $@
 	$(INSTALL) $(SERVER) $(PREFIX)/sbin
 
 test-bof: bof.c 

--- a/tcpborphserver3/Makefile
+++ b/tcpborphserver3/Makefile
@@ -31,10 +31,9 @@ clean:
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@ $(INC)
 
+# Ensure that kcpfpg gets installed
 install: all
-	# Ensure that kcpfpg in installed in /usr so
-	# that upload_to_ram_and_program will work!
-	$(MAKE) -C ../fpg PREFIX=/usr $@
+	$(MAKE) -C ../fpg $@
 	$(INSTALL) $(SERVER) $(PREFIX)/sbin
 
 test-bof: bof.c 


### PR DESCRIPTION
The server-side implementation of the `upload_to_ram_and_program` KATCP
command depends on the server-side `kcpfpg` utility being installed in
`/usr`.  If that utility is not found there, the
`upload_to_ram_and_program` command can fail seemingly mysteriously.